### PR TITLE
Timeout no envio de comandos e UI para pausar e reiniciar o robô

### DIFF
--- a/src/components/RobotChip.vue
+++ b/src/components/RobotChip.vue
@@ -188,7 +188,7 @@ const session = useSessionStore();
 const battery = useBattery();
 
 const batteryLowWarningThresholdOptions = ref(
-  [7900, 7400, 7200, 6900, 6600].map((threshold) => ({
+  [7900, 7600, 7400, 7200, 6900, 6600].map((threshold) => ({
     label: (threshold / 1000).toPrecision(2) + 'V',
     value: threshold,
   }))

--- a/src/components/RobotChip.vue
+++ b/src/components/RobotChip.vue
@@ -117,11 +117,25 @@
 
           <q-separator inset spaced />
 
+          <q-item-label header>Sistema</q-item-label>
+
           <q-item clickable @click="disconnect">
             <q-item-section avatar>
               <q-avatar :icon="mdiBluetoothOff"></q-avatar>
             </q-item-section>
             <q-item-section>Desconectar</q-item-section>
+          </q-item>
+          <q-item clickable :disable="loading !== null" @click="pause">
+            <q-item-section avatar>
+              <q-avatar :icon="mdiCloseCircleOutline"></q-avatar>
+            </q-item-section>
+            <q-item-section>Parar</q-item-section>
+          </q-item>
+          <q-item clickable :disable="loading !== null" @click="resume">
+            <q-item-section avatar>
+              <q-avatar :icon="mdiArrowTopRightThinCircleOutline"></q-avatar>
+            </q-item-section>
+            <q-item-section>Andar</q-item-section>
           </q-item>
         </q-list>
       </div>
@@ -142,12 +156,15 @@ import {
   mdiBluetoothOff,
   mdiBatteryChargingWirelessAlert,
   mdiTrophy,
+  mdiCloseCircleOutline,
+  mdiArrowTopRightThinCircleOutline,
 } from '@quasar/extras/mdi-v6';
 import { onUnmounted, ref, watchEffect } from 'vue';
 import { useTimeoutPoll, useCycleList } from '@vueuse/core';
 import { useArrayMap } from '@vueuse/shared';
 import useFirebase from 'src/services/firebase';
 import { useCompetitions } from 'src/composables/competitions';
+import { useRobotSystem } from 'src/composables/system';
 
 const emit = defineEmits<{
   (e: 'low-battery', currentVoltage: number): void;
@@ -243,4 +260,6 @@ onUnmounted(() => {
   pauseBatteryVoltageUpdate();
   pauseLowBatteryWarning();
 });
+
+const { resume, pause, loading } = useRobotSystem(ble, 'UART_TX', 'UART_RX');
 </script>

--- a/src/components/StreamChartsPanel.vue
+++ b/src/components/StreamChartsPanel.vue
@@ -90,7 +90,7 @@ const streamReader = (currentValues: Robot.RuntimeStream[]) => {
         sum: currentValue,
         receivedValuesCount: 1,
         StreamFullDataCsv:
-          'Values; Time\n' +
+          'Values;Time\n' +
           currentValue.toString() +
           ';' +
           TreatedTime.toString() +

--- a/src/composables/loading.ts
+++ b/src/composables/loading.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue';
 
 // TODO: Implementar timeout (lançar erro quando estourar)
 export const useLoading = () => {
-  const loading = ref<string | null>();
+  const loading = ref<string | null>(null);
 
   /**
    * Retorna uma função, com o nome fornecido, para que a variável de estado
@@ -11,11 +11,13 @@ export const useLoading = () => {
    * @example :loading="loading.value === listParameters.name"
    * @param routine Função para notificar a execução
    * @param routineName Nome da função. Por padrão se utiliza a propriedade (`.name`)
+   * @param timeout Uma função que retorna uma `Promise`, que sempre rejeita, para concorrer com a execução a ser notificada, possibilitando o cancelamento da espera através do lançamento de um erro, por exemplo.
    * @returns Função cuja execução pode ser notificada através da ref `loading`
    */
   function notifyLoading<This, Args extends unknown[], Return>(
     routine: (this: This, ...args: Args) => Promise<Return>,
-    routineName?: string
+    routineName?: string,
+    timeout?: () => Promise<Error>
   ) {
     routineName = routineName || routine.name;
 
@@ -27,7 +29,16 @@ export const useLoading = () => {
         loading.value = routineName || routine.name;
 
         try {
-          const result = await routine.call(this, ...args);
+          const promises: Array<Promise<Return> | Promise<Error>> = [
+            routine.call(this, ...args),
+          ];
+          if (timeout) promises.push(timeout());
+
+          const result = await Promise.race(promises);
+          if (result instanceof Error) {
+            throw result;
+          }
+
           return Promise.resolve(result);
         } finally {
           loading.value = null;

--- a/src/composables/system.ts
+++ b/src/composables/system.ts
@@ -1,0 +1,53 @@
+import { useLoading } from './loading';
+import { useErrorCapturing } from './error';
+import { BleError } from 'src/services/ble/errors';
+import { getTimer } from 'src/services/ble/utils';
+import { ref } from 'vue';
+export const useRobotSystem = (
+  ble: Bluetooth.BLEInterface,
+  txCharacteristicId: string,
+  rxCharacteristicId: string
+) => {
+  const error = ref<unknown>(null);
+  const { loading, notifyLoading } = useLoading();
+
+  const { pause } = useErrorCapturing(
+    notifyLoading(
+      async function () {
+        await ble.request<string>(
+          txCharacteristicId,
+          rxCharacteristicId,
+          'pause'
+        );
+      },
+      'pause',
+      getTimer(5)
+    ),
+    [BleError],
+    error,
+    true
+  );
+
+  const { resume } = useErrorCapturing(
+    notifyLoading(
+      async function () {
+        await ble.request<string>(
+          txCharacteristicId,
+          rxCharacteristicId,
+          'resume'
+        );
+      },
+      'resume',
+      getTimer(5)
+    ),
+    [BleError],
+    error
+  );
+
+  return {
+    pause,
+    resume,
+    loading,
+    error,
+  };
+};

--- a/src/services/ble/errors.ts
+++ b/src/services/ble/errors.ts
@@ -1,11 +1,11 @@
-export class BleError extends Error implements Bluetooth.BaseError {
+export class BleError extends Error implements Dashboard.ErrorInterface {
   readonly name: string;
   readonly action: string;
   readonly message: string;
   readonly cause?: Error;
 
   constructor(
-    { message, action, cause }: Bluetooth.ErrorOptions,
+    { message, action, cause }: Dashboard.ErrorOptions,
     ...args: Array<string | undefined>
   ) {
     super(...args);
@@ -17,7 +17,7 @@ export class BleError extends Error implements Bluetooth.BaseError {
 
 export class RuntimeError extends BleError {
   constructor(
-    { message, action, cause }: Partial<Bluetooth.ErrorOptions> = {},
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
     ...args: Array<string | undefined>
   ) {
     super(
@@ -35,7 +35,7 @@ export class RuntimeError extends BleError {
 
 export class DeviceNotFoundError extends BleError {
   constructor(
-    { message, action, cause }: Partial<Bluetooth.ErrorOptions> = {},
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
     ...args: Array<string | undefined>
   ) {
     super(
@@ -52,7 +52,7 @@ export class DeviceNotFoundError extends BleError {
 
 export class DeviceError extends BleError {
   constructor(
-    { message, action, cause }: Partial<Bluetooth.ErrorOptions> = {},
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
     ...args: Array<string | undefined>
   ) {
     super(
@@ -72,7 +72,7 @@ export class DeviceError extends BleError {
 
 export class ConnectionError extends BleError {
   constructor(
-    { message, action, cause }: Partial<Bluetooth.ErrorOptions> = {},
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
     ...args: Array<string | undefined>
   ) {
     super(
@@ -88,13 +88,32 @@ export class ConnectionError extends BleError {
 
 export class CharacteristicWriteError extends BleError {
   constructor(
-    { message, action, cause }: Partial<Bluetooth.ErrorOptions> = {},
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
     ...args: Array<string | undefined>
   ) {
     super(
       {
         message: message || 'Houve um erro durante o envio de dados ao robô',
         action: action || 'Verifique a configuração da conexão com o robô.',
+        cause,
+      },
+      ...args
+    );
+  }
+}
+
+export class TimeoutError extends BleError {
+  constructor(
+    { message, action, cause }: Partial<Dashboard.ErrorOptions> = {},
+    ...args: Array<string | undefined>
+  ) {
+    super(
+      {
+        message:
+          message || 'O robô demorou tempo demais para responder aos comandos.',
+        action:
+          action ||
+          'Verifique se o robô ainda está conectado e tente novamente.',
         cause,
       },
       ...args

--- a/src/services/ble/utils.ts
+++ b/src/services/ble/utils.ts
@@ -1,0 +1,8 @@
+import { TimeoutError } from './errors';
+
+export function getTimer(seconds: number): () => Promise<TimeoutError> {
+  return async () =>
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new TimeoutError()), seconds * 1000)
+    );
+}

--- a/src/types/ble.d.ts
+++ b/src/types/ble.d.ts
@@ -1,12 +1,4 @@
 declare namespace Bluetooth {
-  type ErrorOptions = { message: string; action: string; cause?: Error };
-
-  interface BaseError extends Error {
-    readonly message: string;
-    readonly action: string;
-    readonly cause?: Error;
-  }
-
   type Message = Record<string, unknown>;
 
   type BleCharacteristicsMap = Map<string, string>;

--- a/src/types/dashboard.d.ts
+++ b/src/types/dashboard.d.ts
@@ -17,4 +17,12 @@ declare namespace Dashboard {
     robot: Robot.BluetoothConnectionConfig;
     settings: Settings;
   }
+
+  type ErrorOptions = { message: string; action: string; cause?: Error };
+
+  interface ErrorInterface extends Error {
+    readonly message: string;
+    readonly action: string;
+    readonly cause?: Error;
+  }
 }


### PR DESCRIPTION
As mudanças incluem a integração dos comandos "resume" e "pause" do Braia, que servem para fazer o robô parar e voltar a se mover, e a implementação de timeouts na espera por respostas aos comandos enviados para que a UI não fique travada.