### PR TITLE
Tratar possíveis erros nas leituras de tensão da bateria

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -122,6 +122,7 @@ const lowBatteryDialog = reactive({
     if (!this.warned) {
       this.voltage = currentVoltage;
       this.show = true;
+      this.warned = true;
     }
   },
 });


### PR DESCRIPTION
Acredito que as travadas na dashboard estejam relacionadas a erros durante a leitura da tensão da bateria via bluetooth. Vi que no código a dashboard assumia que a resposta do robô sempre viria, e com o formato certo, mas isso nem sempre acontece pois ocasionalmente a comunicação com ele falha e a API de bluetooth do navegador lança um erro.
Para corrigir eu fiz a dash passar a capturar os erros lançados durante as requisições pela tensão atual da bateria.