### PR TITLE
Correção do processamento de registros de mapeamento com valores negativos

### DIFF
--- a/src/composables/mapping.ts
+++ b/src/composables/mapping.ts
@@ -17,8 +17,7 @@ export const useRobotMapping = (
   const { undo, redo } = useRefHistory(mappingRecords, { deep: true });
 
   function deserializeRecord(record: string): Robot.MappingRecord {
-    return record.match(
-      /(?<id>\d+)\,(?<time>\d+)\,(?<encMedia>\d+)\,(?<trackStatus>\d+)\,(?<offset>\d+)/
+    return record.match(/(?<id>-?\d+(\.\d+)?),(?<time>-?\d+(\.\d+)?),(?<encMedia>-?\d+(\.\d+)?),(?<trackStatus>-?\d+(\.\d+)?),(?<offset>-?\d+(\.\d+)?)/
     ).groups as unknown as Robot.MappingRecord;
   }
 


### PR DESCRIPTION
Na deserialização dos registros de mapeamento, feita através do método `deserializeRecord`, assumia-se que o robô retorna apenas números inteiros positivos. Como alguns campos podem conter valores negativos e/ou valores de ponto flutuante a leitura do mapeamento estava falhando em certos casos. Nesse pull request isso foi corrigido modificando a regex utilizada no método de modo a extrair corretamente qualquer valor numérico.