### PR TITLE
Remover filtragem das competições pelo ano

### DIFF
--- a/src/components/RobotChip.vue
+++ b/src/components/RobotChip.vue
@@ -243,7 +243,7 @@ watchEffect(() => {
 });
 
 /**
- * TODO: utilizar filtro de ano e tratar erros durante a leitura dos dados do Firestore
+ * TODO: tratar erros durante a leitura dos dados do Firestore
  */
 const { competitions } = useCompetitions(useFirebase().db);
 const competitionsOptions = useArrayMap(

--- a/src/composables/competitions.ts
+++ b/src/composables/competitions.ts
@@ -1,5 +1,5 @@
 import { useFirestore } from '@vueuse/firebase';
-import { collection, query, where } from 'firebase/firestore';
+import { collection, query } from 'firebase/firestore';
 import { ref, computed } from 'vue';
 import type { Firestore, FirestoreDataConverter } from 'firebase/firestore';
 import type { Ref } from 'vue';
@@ -22,21 +22,16 @@ export const useCompetitions = (
   firestore: Firestore
 ): {
   competitions: Ref<Dashboard.Competition[]>;
-  year: Ref<string>;
   error: Ref<Error>;
 } => {
-  const year = ref<string>(new Date().getFullYear().toString());
   const error = ref<Error>();
 
   const competitionsQuery = computed(() =>
-    query(
-      collection(firestore, 'competitions'),
-      where('year', '==', year.value)
-    ).withConverter(converter)
+    query(collection(firestore, 'competitions')).withConverter(converter)
   );
   const competitions = useFirestore(competitionsQuery, undefined, {
     errorHandler: (e: Error) => (error.value = e),
   });
 
-  return { competitions, year, error };
+  return { competitions, error };
 };


### PR DESCRIPTION
A seleção de competições estava mostrando um valor sem sentido pois no carregamento das competições registradas há um filtro pelo ano, e na implementação do componente não foi tratado o caso de uma lista vazia, que ocorreu agora após a chegada de 2024.
Como a implementação de uma UI para gerenciamento de competições não é prioridade no momento, esse pull request apenas remove a filtragem pelo ano, fazendo com que o seletor mostre as competições antigas.